### PR TITLE
Add Etsy API credential placeholders to .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,3 +23,15 @@ LOOKBACK_HOURS=24
 GOOGLE_CREDENTIALS_FILE=google-credentials.json
 GOOGLE_SPREADSHEET_ID=your-spreadsheet-id-here
 GOOGLE_SHEET_NAME=AI News
+
+# ── Etsy API Credentials ─────────────────────────────────────────────────────
+# Get these from https://developers.etsy.com → Your Apps
+# ETSY_API_KEYSTRING   Your app's keystring (client ID)
+# ETSY_SHARED_SECRET   Your app's shared secret
+# ETSY_SHOP_ID         Numeric shop ID (find in page source: search for "shop_id")
+#
+# After setting these, run:  python workflows/etsy_analytics/etsy_oauth.py
+# to complete OAuth and generate etsy_tokens.json
+ETSY_API_KEYSTRING=your-etsy-keystring-here
+ETSY_SHARED_SECRET=your-etsy-secret-here
+ETSY_SHOP_ID=your-shop-id-here


### PR DESCRIPTION
Adds ETSY_API_KEYSTRING, ETSY_SHARED_SECRET, and ETSY_SHOP_ID with setup instructions so credentials don't need to be re-entered each session.

https://claude.ai/code/session_0192CYfzEBVLP2TinyK7z8mJ